### PR TITLE
allow re-using treads so slow collection can be done 1 time.

### DIFF
--- a/src/strpkg/cluster.nim
+++ b/src/strpkg/cluster.nim
@@ -1,4 +1,6 @@
 import algorithm
+import msgpack4nim
+import msgpack4collection
 import math
 import strformat
 import tables
@@ -25,6 +27,45 @@ type tread* = object
   align_length*: uint8
   when defined(debug) or defined(qname):
     qname*: string
+proc pack_type*[ByteStream](s: ByteStream, x: tread) =
+  s.pack(x.tid)
+  s.pack(x.position)
+  s.pack(x.repeat)
+  s.pack(x.flag.uint16)
+  s.pack(x.split.uint8)
+  s.pack(x.mapping_quality)
+  s.pack(x.repeat_count)
+  s.pack(x.align_length)
+  var L:uint32 = 0
+  when defined(debug) or defined(qname):
+    L = x.qname.len.uint32
+    s.pack(L)
+    s.pack(x.qname)
+  else:
+    s.pack(L)
+
+proc unpack_type*[ByteStream](s: ByteStream, x: var tread) =
+  s.unpack(x.tid)
+  s.unpack(x.position)
+  s.unpack(x.repeat)
+  var f:uint16
+  s.unpack(f)
+  x.flag = Flag(f)
+  var split:uint8
+  s.unpack(split)
+  x.split = Soft(split)
+  s.unpack(x.mapping_quality)
+  s.unpack(x.repeat_count)
+  s.unpack(x.align_length)
+  var L:uint32 = 0
+  var qname: string
+  s.unpack(L)
+  qname = newString(L)
+  s.unpack(qname)
+  when defined(debug) or defined(qname):
+    x.qname = qname
+
+
 
 type Cluster* = object
   reads*: seq[tread]

--- a/src/strpkg/collect.nim
+++ b/src/strpkg/collect.nim
@@ -63,12 +63,10 @@ proc count(A: Record, bounds:Bounds): int =
   var dna:string
   A.sequence(dna)
 
-  var read_left = A.find_read_position(bounds.left.int)
-  var read_right = A.find_read_position(bounds.right.int)
-  if read_left < 0: read_left = 0
-  if read_right < 0: read_right = 1
+  var read_left = max(0, A.find_read_position(bounds.left.int))
+  var read_right = max(1, A.find_read_position(bounds.right.int))
 
-  return dna[read_left..read_right].count(bounds.repeat)
+  return dna[read_left..<read_right].count(bounds.repeat)
 
 proc spanning_read*(A:Record, bounds:Bounds, support: var Support): bool =
 

--- a/str.nimble
+++ b/str.nimble
@@ -8,7 +8,7 @@ license       = "MIT"
 
 # Dependencies
 
-requires "nim >= 0.18.0", "kmer", "hts", "itertools", "argparse"
+requires "nim >= 0.18.0", "kmer", "hts", "itertools", "argparse", "msgpack4nim"
 bin = @["str"]
 
 srcDir = "src"


### PR DESCRIPTION
also support a fast-mode when compile with -d:skipFullMatch with the assumption that reads with cigar of 151M are not going to be repetitive. this may not always be true, but it makes the program 7X faster.

