### PR TITLE
find repetitive regions in reference

### DIFF
--- a/src/strpkg/genome_strs.nim
+++ b/src/strpkg/genome_strs.nim
@@ -1,0 +1,175 @@
+import hts/fai
+import random
+import argparse
+import tables
+import lapper
+import algorithm
+import strutils
+import ./utils
+import strformat
+import ./read_bed
+export read_bed
+
+type Window = object
+  chrom: string
+  start: int
+  stop: int
+  repeat: string
+
+
+proc trim(w:var Window, dna:string): Window =
+  doAssert dna.len == w.stop - w.start
+  var ow = w
+
+  var expected:uint64
+  for v in w.repeat.slide_by(w.repeat.len):
+    expected = v
+    break
+
+  # NOTE: this stops trimming on first mis-matching kmer. could require 2 mismatches in a row
+  # or something, but this actually works well AFAICT
+
+  # trim left
+  for enc in dna.slide_by(w.repeat.len):
+    if expected != enc: w.start += w.repeat.len
+    else: break
+
+  doAssert w.start < w.stop, &"repeat {w.repeat} not found in expected region for {ow}, {dna}"
+
+  # trim right
+  var dnar = newString(dna.len)
+  # reverse the repeat and the dna sequence.
+  for i, x in dna:
+    # high == len - 1
+    dnar[dna.high-i] = x
+
+  var rep = w.repeat
+  rep.reverse
+  for v in rep.slide_by(w.repeat.len):
+    expected = v
+    break
+
+  for enc in dnar.slide_by(w.repeat.len):
+    if expected != enc: w.stop -= w.repeat.len
+    else: break
+
+  doAssert w.start < w.stop, &"repeat {w.repeat} not found in expected region for {ow}, {dna}"
+  return w
+
+iterator repeat_windows(fai:Fai, window_size:int, step:int, opts:Options): Window =
+  var counts = init[uint8]()
+  var repeat_count:int
+  for tid in 0..<fai.len:
+    var chrom = fai[tid]
+    stderr.write_line &"[str] on chromosome: {chrom}"
+    var start = 0
+    var L = fai.chrom_len(chrom)
+    var last_w = Window(stop: -1)
+    var chrom_seq = fai.get(chrom)
+    shallow(chrom_seq)
+    while start < L:
+      var dna = chrom_seq[start..<min(L, start + window_size)]
+      var rep = dna.get_repeat(counts, repeat_count, opts)
+      if repeat_count > 0:
+        var w = Window(chrom: chrom, start: start, stop: start + dna.len, repeat: rep.tostring)
+        # allow skipping 1 window.
+        if last_w.repeat != w.repeat or w.start > last_w.stop + (window_size-step):
+          if last_w.stop != -1 and last_w.stop - last_w.start >= (window_size - step):
+            last_w.start = max(0, last_w.start - window_size)
+            last_w.stop = min(last_w.stop + window_size, chrom_seq.len)
+            yield last_w.trim(chrom_seq[last_w.start..<last_w.stop])
+          last_w = w
+        else:
+          last_w.stop = w.stop
+
+      start += step
+
+    if last_w.stop != -1 and last_w.stop - last_w.start >= (window_size - step):
+      last_w.start = max(0, last_w.start - window_size)
+      last_w.stop = min(last_w.stop + window_size, chrom_seq.len)
+      yield last_w.trim(chrom_seq[last_w.start..<last_w.stop])
+
+proc getTempFile*(): string =
+  ## from Nimble
+  var tmpdir: string
+  if existsEnv("TMPDIR") and existsEnv("USER"):
+    tmpdir = joinPath(getEnv("TMPDIR"), getEnv("USER"))
+  else:
+    tmpdir = getTempDir()
+  discard existsOrCreateDir(tmpdir)
+  randomize()
+
+  result = tmpdir / $rand(int.high) & $rand(int.high) & ".bed"
+
+
+proc genome_repeats*(fai:Fai, opts:Options, bed_path:string): TableRef[string, Lapper[region]] =
+  ## find repeats in the genome. this helps as we can for example skip
+  ## reads that are a perfect match to the genome when that part of the genome
+  ## is not a repeat.
+  var bed_path = bed_path
+  var isTmp = bed_path == ""
+  if isTmp:
+    bed_path = getTempFile()
+
+
+  if not fileExists(bed_path):
+    var fh:File
+    if not fh.open(bed_path, fmWrite):
+      quit &"[str] couldn't open bed file: {bed_path} for writing"
+    let window_size: int = 100
+    let step: int = 60
+
+
+    for w in fai.repeat_windows(window_size, step, opts):
+      fh.write_line(&"{w.chrom}\t{w.start}\t{w.stop}\t{w.repeat}")
+    fh.close
+  else:
+    stderr.write_line &"[str] using existing file {bed_path} for genome repeats"
+
+  result = read_bed(bed_path)
+  stderr.write_line &"[str] got STR repeats from genome into an interval tree"
+  if isTmp:
+    removeFile(bed_path)
+
+proc genome_repeats*(fasta:string, opts:Options, bed_path:string): TableRef[string, Lapper[region]] =
+  var fai:Fai
+  if not fai.open(fasta):
+    quit &"[str] couldn't open fasta {fasta} make sure file is present and has a .fai index"
+  result = fai.genome_repeats(opts, bed_path)
+
+proc genome_main*() =
+
+  var p = newParser("str genome-sites"):
+    option("-p", "--proportion-repeat", help="proportion of read that is repetitive to be considered as STR", default="0.65")
+    arg("fasta", help="path to fasta file")
+    arg("bed", help="path to output bed file to be created")
+
+  var argv = commandLineParams()
+  if len(argv) > 0 and argv[0] == "genome-sites":
+    argv = argv[1..argv.high]
+  if len(argv) == 0: argv = @["--help"]
+
+  var args = p.parse(argv)
+  if args.help:
+    quit 0
+
+  var fai:Fai
+  if not fai.open(args.fasta):
+    quit &"[str] couldn't open fasta {args.fasta} make sure file is present and has a .fai index"
+
+  var opts = Options(proportion_repeat: parseFloat(args.proportion_repeat))
+  discard fai.genome_repeats(opts, args.bed)
+
+when isMainModule:
+
+  #[
+  import unittest
+  suite "genome strs":
+    test "bug":
+      var w = Window(chrom: "MT", start: 16460, stop: 16569, repeat: "CACGAT")
+      var dna = "ATAACACTTGGGGGTAGCTAAAGTGAACTGTATCCGACATCTGGTTCCTACTTCAGGGTCATAAAGCCTAAATAGCCCACACGTTCCCCTTAAATAAGACATCACGATG"
+      echo w.trim(dna)
+  ]#
+
+  genome_main()
+

--- a/src/strpkg/read_bed.nim
+++ b/src/strpkg/read_bed.nim
@@ -1,0 +1,51 @@
+import strutils
+import tables
+import lapper
+import hts
+export tables
+export lapper
+
+type
+  region* = object
+    chrom*: string
+    start*: int
+    stop*: int
+    #name: string
+
+proc start*(r: region): int {.inline.} = r.start
+proc stop*(r: region): int {.inline.} = r.stop
+
+proc bed_line_to_region(line: string): region =
+  var
+    cse = line.strip().split('\t', 5)
+  if len(cse) < 3:
+    stderr.write_line("[slivar] skipping bad bed line:", line.strip())
+    return
+  result.start = parse_int(cse[1])
+  result.stop = parse_int(cse[2])
+  result.chrom = cse[0]
+   #if len(cse) > 3:
+   #  reg.name = cse[3]
+
+proc read_bed*(bed: string): TableRef[string, Lapper[region]] =
+  var bed_regions = newTable[string, seq[region]]()
+  var kstr = kstring_t(l:0, m: 0, s: nil)
+  var hf = hts_open(cstring(bed), "r")
+  while hts_getline(hf, cint(10), addr kstr) > 0:
+    if kstr.s[0] == 't' and ($kstr.s).startswith("track "):
+      continue
+    if kstr.s[0] == '#':
+      continue
+    var v = bed_line_to_region($kstr.s)
+    if v.chrom.len == 0: continue
+    discard bed_regions.hasKeyOrPut(v.chrom, new_seq[region]())
+    bed_regions[v.chrom].add(v)
+
+  # since it is read into mem, can also well sort.
+  result = newTable[string, Lapper[region]]()
+  for chrom, ivs in bed_regions.mpairs:
+    result[chrom] = lapify(ivs)
+
+  hts.free(kstr.s)
+  return result
+

--- a/str.nimble
+++ b/str.nimble
@@ -8,7 +8,7 @@ license       = "MIT"
 
 # Dependencies
 
-requires "nim >= 0.18.0", "kmer >= 0.2.2", "hts", "itertools", "argparse", "msgpack4nim"
+requires "nim >= 0.18.0", "kmer >= 0.2.2", "hts", "itertools", "argparse", "msgpack4nim", "lapper"
 bin = @["str"]
 
 srcDir = "src"

--- a/str.nimble
+++ b/str.nimble
@@ -8,7 +8,7 @@ license       = "MIT"
 
 # Dependencies
 
-requires "nim >= 0.18.0", "kmer", "hts", "itertools", "argparse", "msgpack4nim"
+requires "nim >= 0.18.0", "kmer >= 0.2.2", "hts", "itertools", "argparse", "msgpack4nim"
 bin = @["str"]
 
 srcDir = "src"

--- a/tests/test_str.nim
+++ b/tests/test_str.nim
@@ -60,7 +60,7 @@ suite "str suite":
     var repeat_count = 0
     var align_length = 0
 
-    var rep = a.get_repeat(counts, repeat_count, align_length, opts)
+    var rep = a.get_repeat(nil, counts, repeat_count, align_length, opts)
     check rep == ['A', 'A', '\x00', '\x00', '\x00', '\x00']
 
 


### PR DESCRIPTION
reads that map perfectly to non-repetetive regions
of the genome can't be repetitive so we can skip
the repeat calculation on them.

this improves the reads/sec from ~120K/sec to ~800K/sec
after an initial 4 minute penalty of calculating the reference
repeat content

it can also write the str content to a file (and then re-use it) so that step is
only needed once.